### PR TITLE
after selecting rectangle, remove mouse event handler

### DIFF
--- a/extension/clip.js
+++ b/extension/clip.js
@@ -47,6 +47,7 @@ function mouseUpHandler(e) {
     if (rect.width > 0) {
         var info = collectInformation();
         chrome.runtime.sendMessage(info);
+        removeMouseEventHandler();
         clearRect();
     }
 }
@@ -56,6 +57,12 @@ function mouseMoveHandler(e) {
         endPoint = getPoint(e);
         drawRect(startPoint, endPoint);
     }
+}
+
+function removeMouseEventHandler() {
+    window.onmousedown = null;
+    window.onmouseup   = null;
+    window.onmousemove = null;
 }
 
 function clearRect() {


### PR DESCRIPTION
アイコンをクリックすると常に範囲選択の矩形が出てきちゃうので、範囲選択後にマウス関連のハンドラを削除するようにしてみました。
gitやgithubに慣れていないので、何か間違いなどがあるようでしたら指摘ください。
